### PR TITLE
wizzy_quest: Update quest metadata with complete project info

### DIFF
--- a/scenes/quests/story_quests/wizzy_quest/quest.tres
+++ b/scenes/quests/story_quests/wizzy_quest/quest.tres
@@ -1,10 +1,15 @@
-[gd_resource type="Resource" script_class="Quest" load_steps=2 format=3 uid="uid://onwaocv0de6e"]
+[gd_resource type="Resource" script_class="Quest" load_steps=3 format=3 uid="uid://onwaocv0de6e"]
 
 [ext_resource type="Script" uid="uid://dts1hwdy3phin" path="res://scenes/menus/storybook/components/quest.gd" id="1_ukbr7"]
+[ext_resource type="SpriteFrames" uid="uid://b1sol6f5xak4b" path="res://scenes/quests/story_quests/wizzy_quest/player_components/wizzy_quest_player.tres" id="2_8cyu4"]
 
 [resource]
 script = ExtResource("1_ukbr7")
-title = "WizzyQuest"
-description = "Este quest es acerca de un joven que adquiere poderes cuando encuentra runas"
+title = "Eldrune"
+description = "Lyrem es un joven mago de Eldline con un don inusual: puede escuchar las runas elementales. Mientras que la mayoría de los magos dominan un solo elemento —tres en el caso de los excepcionalmente talentosos—, Lyrem puede dominar tantos como descubra. Guiado por susurros ancestrales hacia runas prohibidas ocultas en templos y ruinas, adquiere nuevos poderes y descubre una oscura verdad: el Rey Malvado está regresando."
+authors = Array[String](["Josué Carmelo Murga Guimaray", "Jhonny Denis Mamani Moreno", "Edu Sergio Lazo Armas", "Manuel Augusto Díaz Guarda"])
+affiliation = "UTP"
 first_scene = "uid://bsn51v3gfmtvn"
+sprite_frames = ExtResource("2_8cyu4")
+animation_name = &"attack_02"
 metadata/_custom_type_script = "uid://dts1hwdy3phin"


### PR DESCRIPTION
Updated the quest.tres file to reflect the final project details:
- Changed title from "WizzyQuest" to "Eldrune"
- Expanded description with the story premise about Lyrem, a young mage
  who can hear elemental runes and discovers the Dark King's return
  (written in Spanish for this StoryQuest)
- Added all four team members as authors
- Added UTP affiliation
- Added player sprite frames with attack_02 animation for the quest card